### PR TITLE
Add larger session object

### DIFF
--- a/app/src/main/java/com/eternus/tomcat/CleanupObject.java
+++ b/app/src/main/java/com/eternus/tomcat/CleanupObject.java
@@ -19,8 +19,11 @@ public class CleanupObject implements HttpSessionBindingListener, Serializable {
 
     private String id;
 
-    CleanupObject(String id) {
+    private byte[] body;
+
+    CleanupObject(String id, int size) {
         this.id = id;
+        this.body = DevURandom.readRandom(size);
     }
 
     @Override
@@ -35,6 +38,6 @@ public class CleanupObject implements HttpSessionBindingListener, Serializable {
 
     @Override
     public String toString() {
-        return this.id;
+        return String.format("%s, %d bytes", this.id, this.body == null ? 0 : this.body.length);
     }
 }

--- a/app/src/main/java/com/eternus/tomcat/DevURandom.java
+++ b/app/src/main/java/com/eternus/tomcat/DevURandom.java
@@ -1,0 +1,17 @@
+package com.eternus.tomcat;
+
+import java.security.SecureRandom;
+
+/**
+ *
+ */
+public class DevURandom {
+
+    private static SecureRandom randomness = new SecureRandom();
+
+    public static byte[] readRandom(int size) {
+        byte[] result = new byte[size];
+        randomness.nextBytes(result);
+        return result;
+    }
+}

--- a/app/src/main/java/com/eternus/tomcat/HelloController.java
+++ b/app/src/main/java/com/eternus/tomcat/HelloController.java
@@ -5,16 +5,20 @@ import javax.servlet.http.HttpSession;
 
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.beans.factory.annotation.Value;
 
 @RestController
 public class HelloController {
 
     public static final String MY_USER_SESSION = "my-user-session";
 
+    @Value("${session.size_bytes}")
+    private int sessionSizeBytes;
+
     @RequestMapping("/")
     String index(HttpSession session) {
         if (session.getAttribute(MY_USER_SESSION) == null) {
-            session.setAttribute(MY_USER_SESSION, new CleanupObject(session.getId()));
+            session.setAttribute(MY_USER_SESSION, new CleanupObject(session.getId(), sessionSizeBytes));
         }
         return session.getId();
     }

--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -1,3 +1,4 @@
+session.size_bytes=1024
 spring.session.store-type=jdbc
 # Session timeout in seconds.
 server.session.timeout=60

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,42 +1,59 @@
-db:
-  image: mysql:5.7.21
-  environment:
-    MYSQL_ROOT_PASSWORD: strong-passw0rd
-    MYSQL_DATABASE: myapp
-    MYSQL_USER: myapp_user
-    MYSQL_PASSWORD: myapp_pass
-  ports:
-    - 3306:3306
+version: "3"
 
-app_1:
-  image: jabley/stateless-tomcat:latest
-  ports:
-    - "8081:8080"
-  links:
-    - db
+services:
+  db:
+    image: mysql:5.7.21
+    environment:
+      MYSQL_ROOT_PASSWORD: strong-passw0rd
+      MYSQL_DATABASE: myapp
+      MYSQL_USER: myapp_user
+      MYSQL_PASSWORD: myapp_pass
+    volumes:
+      - "./mysql:/docker-entrypoint-initdb.d"
+    ports:
+      - 3306:3306
+    command: ['--max_allowed_packet=16M']
 
-app_2:
-  image: jabley/stateless-tomcat:latest
-  ports:
-    - "8082:8080"
-  links:
-    - db
+  app_1:
+    image: jabley/stateless-tomcat:latest
+    environment:
+      CATALINA_OPTS: -Dsession.size_bytes=${SESSION_SIZE:-1024}
+      JPDA_SUSPEND: n
+      JPDA_ADDRESS: 8000
+      JPDA_TRANSPORT: dt_socket
+    command: catalina.sh jpda run
+    ports:
+      - "8000:8000"
+      - "8081:8080"
+    links:
+      - db
 
-app_3:
-  image: jabley/stateless-tomcat:latest
-  ports:
-    - "8083:8080"
-  links:
-    - db
-    
-# haproxy container that automatically creates a load balancer / reverse proxy across the 3 instances of the app
-haproxy:
-  image: haproxy:1.8.4
-  ports:
-    - "80:80"
-  volumes:
-    - "./haproxy/haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg"
-  links:
-    - app_1
-    - app_2
-    - app_3
+  app_2:
+    image: jabley/stateless-tomcat:latest
+    environment:
+      CATALINA_OPTS: -Dsession.size_bytes=${SESSION_SIZE:-1024}
+    ports:
+      - "8082:8080"
+    links:
+      - db
+
+  app_3:
+    image: jabley/stateless-tomcat:latest
+    environment:
+      CATALINA_OPTS: -Dsession.size_bytes=${SESSION_SIZE:-1024}
+    ports:
+      - "8083:8080"
+    links:
+      - db
+
+  # haproxy container that automatically creates a load balancer / reverse proxy across the 3 instances of the app
+  haproxy:
+    image: haproxy:1.8.4
+    ports:
+      - "80:80"
+    volumes:
+      - "./haproxy/haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg"
+    links:
+      - app_1
+      - app_2
+      - app_3


### PR DESCRIPTION
We want to measure the impact of serialising a large session object.
This change adds a byte array filled with random bytes to the object
being serialised.

Various timing runs where conducted where the size of the byte array
was changed, then the test was run for 30 minutes to get the JIT to
start working, then the benchmark was taken.

```sh
SESSION_SIZE=2048 docker-compose up -d app_1
wrk -d 30m -c 1 -t 1 http://localhost:8081/stateless-tomcat/
wrk -d 20m -c 1 -t 1 http://localhost:8081/stateless-tomcat/
```

The MySQL configuration change was needed to write the 10MB session
object successfully.